### PR TITLE
Auto corrected by following Format Typescript Code

### DIFF
--- a/src/rewriter.ts
+++ b/src/rewriter.ts
@@ -548,15 +548,18 @@ class Rewriter {
   private heredoc(text: string): string {
     let addNewLine = false;
     const lines = text.split("\n");
-    if (lines.length > 0 && lines[0] === '') {
+    if (lines.length > 0 && lines[0] === "") {
       lines.shift();
     }
-    if (lines.length > 0 && lines[lines.length - 1].trim() === '') {
+    if (lines.length > 0 && lines[lines.length - 1].trim() === "") {
       lines.pop();
       addNewLine = true;
     }
     const indent = lines[0].search(/[^ ]/);
-    return lines.map((line) => line.slice(indent)).join('\n') + (addNewLine ? '\n' : '');
+    return (
+      lines.map((line) => line.slice(indent)).join("\n") +
+      (addNewLine ? "\n" : "")
+    );
   }
 }
 

--- a/test/rewriter.spec.ts
+++ b/test/rewriter.spec.ts
@@ -350,7 +350,9 @@ describe("static register", () => {
         }
       );
       rewriter.process();
-      expect(rewriter.description()).toBe(`this is a snippet description.\n\nfoo.bar\n`);
+      expect(rewriter.description()).toBe(
+        `this is a snippet description.\n\nfoo.bar\n`
+      );
     });
   });
 


### PR DESCRIPTION
Auto corrected by following Format Typescript Code

Click [here](https://awesomecode.io/repos/xinminlabs/synvert-core-javascript/format_configs/typescript) to configure it on awesomecode.io